### PR TITLE
Raspberry Pi v1 & v2 kernel compile support

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -21,7 +21,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
+apt-get update
 apt-get install -y git unzip build-essential libncurses5-dev
 
 if [ ! -f /usr/sbin/adabuild ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,8 +102,8 @@ fi
 # make sure tools dir is up to date
 cd $TOOLS_DIR
 git pull
-CCPREFIX=${TOOLS_DIR}/arm-bcm2708/arm-bcm2708-linux-gnueabi/bin/arm-bcm2708-linux-gnueabi-
-
+CCPREFIX="${TOOLS_DIR}/arm-bcm2708/arm-bcm2708-linux-gnueabi/bin/arm-bcm2708-linux-gnueabi-"
+GCCPREFIX="${CCPREFIX}gcc -mcpu=cortex-a7"
 # make sure firmware dir is up to date
 cd $FIRMWARE_DIR
 git pull
@@ -118,13 +118,13 @@ git pull
 git submodule update --init
 cp ${COMPILE_CONFIG} .config
 
-ARCH=arm CROSS_COMPILE=${CCPREFIX} make menuconfig
+ARCH=arm CROSS_COMPILE=${CCPREFIX} CC=${GCCPREFIX} make menuconfig
 echo "**** SAVING A COPY OF YOUR CONFIG TO /vagrant/saved_config ****"
 cp .config /vagrant/saved_config
 
 echo "**** COMPILING KERNEL ****"
-ARCH=arm CROSS_COMPILE=${CCPREFIX} make -j${NUM_CPUS} -k
-ARCH=arm CROSS_COMPILE=${CCPREFIX} INSTALL_MOD_PATH=${MOD_DIR} make -j${NUM_CPUS} modules_install
+ARCH=arm CROSS_COMPILE=${CCPREFIX} CC=${GCCPREFIX} make -j${NUM_CPUS} -k
+ARCH=arm CROSS_COMPILE=${CCPREFIX} CC=${GCCPREFIX} INSTALL_MOD_PATH=${MOD_DIR} make -j${NUM_CPUS} modules_install
 
 # pull together the debian package folder
 cp -r /kernel_builder/package/* $PKG_DIR

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -130,7 +130,7 @@ ARCH=arm CROSS_COMPILE=${CCPREFIX} INSTALL_MOD_PATH=${MOD_DIR} make -j${NUM_CPUS
 # pull together the debian package folder
 cp -r /kernel_builder/package/* $PKG_DIR
 mkdir $PKG_DIR/boot
-BOOT_FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img start.elf start_cd.elf start_x.elf"
+BOOT_FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img start.elf start_cd.elf start_x.elf"
 for FN in $BOOT_FILES; do
   cp $FIRMWARE_DIR/boot/$FN $PKG_DIR/boot
 done

--- a/scripts/package/DEBIAN/postinst
+++ b/scripts/package/DEBIAN/postinst
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel_cutdown.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
+FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img kernel_cutdown.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
 
 for FN in $FILES; do
   # Need to rm first to avoid error "rename involves overwriting ... with 

--- a/scripts/package/DEBIAN/postinst
+++ b/scripts/package/DEBIAN/postinst
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img kernel_cutdown.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
+FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img kernel_cutdown.img kernel7_emergency.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
 
 for FN in $FILES; do
   # Need to rm first to avoid error "rename involves overwriting ... with 

--- a/scripts/package/DEBIAN/preinst
+++ b/scripts/package/DEBIAN/preinst
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel_cutdown.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
+FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img kernel_cutdown.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
 
 # dpkg-divert will error out otherwise
 mkdir -p /usr/share/rpikernelhack

--- a/scripts/package/DEBIAN/preinst
+++ b/scripts/package/DEBIAN/preinst
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img kernel_cutdown.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
+FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img kernel_cutdown.img kernel7_emergency.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
 
 # dpkg-divert will error out otherwise
 mkdir -p /usr/share/rpikernelhack


### PR DESCRIPTION
This branch adds a step to support compiling kernels for the Pi v1 & v2.  The `-c` config file argument was replaced with `-1` for the config file for the RasPi v1 kernel config and `-2` for the RasPi v2 config file.

```
~$ sudo adabuild -h
usage: adabuild [options]
 This will build the Raspberry Pi Kernel.
 OPTIONS:
    -h        Show this message
    -r        The remote git repo to clone
              Default: https://github.com/raspberrypi/linux
    -b        The git branch to use
              Default: Default git branch of repo
    -1        The config file to use when compiling for Raspi v1
              Default: arch/arm/configs/bcmrpi_defconfig
    -2        The config file to use when compiling for Raspi v2
              Default: arch/arm/configs/bcm2709_defconfig
```
