### PR TITLE
no public network needed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "ubuntu/precise32"
 
-  config.vm.network "public_network"
-
   config.vm.provider "virtualbox" do |v|
 
     v.gui = false


### PR DESCRIPTION
Thanks for this great repo! This helps me a lot to build RPi kernels.

I wondered why the Vagrant box needs a public network, so I removed that line. Then the VM just uses the hosts interface in NAT mode and still can download the GitHub repos for firmware and tools.

This simplifies the `vagrant up` step as the user is no longer asked which network to use.
