### PR TITLE
Modified "git clone" command line to permit correct --depth 1 cloning when the user specifies a non-default branch to the script.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,7 +66,7 @@ function clone() {
   echo "**** CLONING to ${REPO_ROOT}${GIT_REPO} ****"
   echo "REPO: ${GIT_REPO}"
   echo "BRANCH: ${GIT_BRANCH}"
-  git clone --depth 1 --recursive https://github.com/${GIT_REPO} $V1_DIR
+  git clone --depth 1 -b ${GIT_BRANCH} --recursive https://github.com/${GIT_REPO} $V1_DIR
   cp -r $V1_DIR $V2_DIR
 }
 


### PR DESCRIPTION
This change should address the issue I opened yesterday.  The current version of the script does a --depth 1 clone of the default branch.  If the user specifies an alternate branch from the default Raspi linux repo (e.g. rpi-3.19.y, etc.) the pruned clone will throw an error when the script later tries to check out the branch.  Adding the parameter to the clone command ensures that the requested branch is what is cloned in the first place.
